### PR TITLE
adding color for links

### DIFF
--- a/webdash-pwa-manifest.html
+++ b/webdash-pwa-manifest.html
@@ -154,6 +154,18 @@
         margin-left: auto;
         margin-right: auto;
       }
+
+      a {
+        color: inherit;
+      }
+
+      empty-state-webdash a {
+        color: var(--brand)
+      }
+
+      empty-state-webdash a:hover {
+        color: var(--accent)
+      }
     </style>
 
     <div id="plugin">


### PR DESCRIPTION
Little pull request to add color to the link if no manifest is found

This link

![before](https://user-images.githubusercontent.com/18487606/39247708-79694696-489a-11e8-997c-a979015338bf.png)

becomes

![after](https://user-images.githubusercontent.com/18487606/39247712-7b768b88-489a-11e8-85fc-76391abcbf32.png)
